### PR TITLE
upd categories-list width

### DIFF
--- a/src/sass/_style-main-box.scss
+++ b/src/sass/_style-main-box.scss
@@ -264,13 +264,18 @@
 // Sidebar
 // Секція список категорій
 .categories-list {
-  width: 100%;
+  width: 336px;
   max-height: 228px;
   overflow-y: scroll;
 }
 @media screen and (min-width: 768px) {
   .categories-list {
     max-height: 472px;
+  }
+}
+@media screen and (min-width: 1440px) {
+  .categories-list {
+    width: 356px;
   }
 }
 .categories-list::-webkit-scrollbar {


### PR DESCRIPTION
Підправив ширину списку категорій до тих значень, що були на макеті, оскільки після останніх змін ширина sideboard зменшилася приблизно до 300px і при великих назвах категорій, текст не вміщався і скупчувався. На роботу головної частини з книжками це не повпливало.